### PR TITLE
Add canva.com

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -45,3 +45,4 @@ discord.app
 sway.office.com
 rockstargames.com
 noscript.net
+canva.com


### PR DESCRIPTION
Apparently, canva.com is flagged as a phishing website by 'Phishing.Database'.