### PR TITLE
Whitelist survey.alchemer.com

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -55,3 +55,4 @@ nvidia.com
 jotform.com
 jsbin.com
 ovh.co.uk
+survey.alchemer.com


### PR DESCRIPTION
Survey service used by discord themselves for the Discord Moderator Test. 
Flagged by Phishing.Database

https://discord.com/moderation/exam
This is official discord link that redirect to one of the surveys