### PR TITLE
Whitelist the discordbots.app domain

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -59,3 +59,4 @@ jsbin.com
 ovh.co.uk
 survey.alchemer.com
 adf.ly
+discordbots.app

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -59,4 +59,5 @@ jsbin.com
 ovh.co.uk
 survey.alchemer.com
 adf.ly
+# Miscellaneous
 discordbots.app


### PR DESCRIPTION
The link is a legitimate link to a bot list app that uses the data of other bot lists that have approved that type of usage, not a discord rip-off and it uses discord's own oauth2 integration to log users in. Therefore, there's no reason for this url to be flagged.