### PR TITLE
Whitelist ffm.to

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -63,4 +63,4 @@ ams3.digitaloceanspaces.com
 digitaloceanspaces.com
 backblazeb2.com
 linkr.bio
-
+ffm.to


### PR DESCRIPTION
Redirects to https://feature.fm/ which is a marketing analytical tool. Not malicious