### PR TITLE
Add cash.app

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -65,4 +65,5 @@ backblazeb2.com
 linkr.bio
 ffm.to
 urlz.fr
+cash.app
 


### PR DESCRIPTION
This is what the domain i actually wanted to add to whitelist. Cash.app is similar like paypal, venmo etc a payment system.