### PR TITLE
anaconda.org  whitelist

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -73,3 +73,4 @@ firebasestorage.googleapis.com
 amazonaws.com
 telegra.ph
 vodafone.de
+anaconda.org 


### PR DESCRIPTION
basically create websites and they offer subdomain. Should not blacklist apex domain at all