### PR TITLE
Add codepen short URL to whitelist

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -73,4 +73,5 @@ firebasestorage.googleapis.com
 amazonaws.com
 telegra.ph
 vodafone.de
-anaconda.org 
+anaconda.org
+cdpn.io


### PR DESCRIPTION
cdpn.io is just a short url for codepen - user content can be hosted there but this domain itself isn't malicious 